### PR TITLE
修复ThreadGroup拼写错误，修复ThreadGroup创建方式

### DIFF
--- a/article/01/3.md
+++ b/article/01/3.md
@@ -147,7 +147,7 @@ Thread.currentThread().getThreadGroup().getName()
 ~~~java
 // 复制一个线程数组到一个线程组
 Thread[] threads = new Thread[threadGroup.activeCount()];
-TheadGroup threadGroup = new ThreadGroup();
+ThreadGroup threadGroup = new ThreadGroup("threadGroup");
 threadGroup.enumerate(threads);
 ~~~
 


### PR DESCRIPTION
new ThreadGroup()为私有构造，无法创建